### PR TITLE
explicitly state template argument

### DIFF
--- a/ipa_room_segmentation/CMakeLists.txt
+++ b/ipa_room_segmentation/CMakeLists.txt
@@ -91,6 +91,7 @@ add_executable(room_segmentation_server
 	common/src/room_class.cpp
 	common/src/voronoi_random_field_segmentation.cpp
 	common/src/clique_class.cpp
+	common/src/cv_boost_loader.cpp
 	common/src/voronoi_random_field_features.cpp)
 target_compile_options(room_segmentation_server PRIVATE ${OpenMP_FLAGS})
 add_dependencies(room_segmentation_server

--- a/ipa_room_segmentation/common/include/ipa_room_segmentation/adaboost_classifier.h
+++ b/ipa_room_segmentation/common/include/ipa_room_segmentation/adaboost_classifier.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "ros/ros.h"
 #include <opencv2/opencv.hpp>
 #include <iostream>

--- a/ipa_room_segmentation/common/include/ipa_room_segmentation/cv_boost_loader.h
+++ b/ipa_room_segmentation/common/include/ipa_room_segmentation/cv_boost_loader.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <opencv2/opencv.hpp>
+
+#if CV_MAJOR_VERSION == 2
+void loadBoost(CvBoost& boost, std::string const& filename);
+#else
+void loadBoost(cv::Ptr<cv::ml::Boost> boost, std::string const& filename);
+#endif

--- a/ipa_room_segmentation/common/include/ipa_room_segmentation/voronoi_random_field_segmentation.h
+++ b/ipa_room_segmentation/common/include/ipa_room_segmentation/voronoi_random_field_segmentation.h
@@ -56,7 +56,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************/
-
+#pragma once
 #include "ros/ros.h"
 
 #include <opencv2/opencv.hpp>

--- a/ipa_room_segmentation/common/src/adaboost_classifier.cpp
+++ b/ipa_room_segmentation/common/src/adaboost_classifier.cpp
@@ -2,6 +2,7 @@
 
 #include <ipa_room_segmentation/wavefront_region_growing.h>
 #include <ipa_room_segmentation/contains.h>
+#include <ipa_room_segmentation/cv_boost_loader.h>
 
 #include <ipa_room_segmentation/timer.h>
 
@@ -232,21 +233,13 @@ void AdaboostClassifier::segmentMap(const cv::Mat& map_to_be_labeled, cv::Mat& s
 		std::string filename_room_default = classifier_default_path + "semantic_room_boost.xml";
 		if (boost::filesystem::exists(boost::filesystem::path(filename_room)) == false)
 			boost::filesystem::copy_file(filename_room_default, filename_room);
-#if CV_MAJOR_VERSION == 2
-    room_boost_.load(filename_room.c_str());
-#else
-    room_boost_->load<cv::ml::Boost>(filename_room.c_str());
-#endif
+		loadBoost(room_boost_, filename_room);
 
 		std::string filename_hallway = classifier_storage_path + "semantic_hallway_boost.xml";
 		std::string filename_hallway_default = classifier_default_path + "semantic_hallway_boost.xml";
 		if (boost::filesystem::exists(boost::filesystem::path(filename_hallway)) == false)
 			boost::filesystem::copy_file(filename_hallway_default, filename_hallway);
-#if CV_MAJOR_VERSION == 2
-    hallway_boost_.load(filename_hallway.c_str());
-#else
-    hallway_boost_->load<cv::ml::Boost>(filename_hallway.c_str());
-#endif
+		loadBoost(hallway_boost_,filename_hallway);
 
 		trained_ = true;
 		ROS_INFO("Loaded training results.");

--- a/ipa_room_segmentation/common/src/adaboost_classifier.cpp
+++ b/ipa_room_segmentation/common/src/adaboost_classifier.cpp
@@ -233,7 +233,7 @@ void AdaboostClassifier::segmentMap(const cv::Mat& map_to_be_labeled, cv::Mat& s
 		if (boost::filesystem::exists(boost::filesystem::path(filename_room)) == false)
 			boost::filesystem::copy_file(filename_room_default, filename_room);
 #if CV_MAJOR_VERSION == 2
-    room_boost_.load<cv::ml::Boost>(filename_room.c_str());
+    room_boost_.load(filename_room.c_str());
 #else
     room_boost_->load<cv::ml::Boost>(filename_room.c_str());
 #endif
@@ -243,7 +243,7 @@ void AdaboostClassifier::segmentMap(const cv::Mat& map_to_be_labeled, cv::Mat& s
 		if (boost::filesystem::exists(boost::filesystem::path(filename_hallway)) == false)
 			boost::filesystem::copy_file(filename_hallway_default, filename_hallway);
 #if CV_MAJOR_VERSION == 2
-    hallway_boost_.load<cv::ml::Boost>(filename_hallway.c_str());
+    hallway_boost_.load(filename_hallway.c_str());
 #else
     hallway_boost_->load<cv::ml::Boost>(filename_hallway.c_str());
 #endif

--- a/ipa_room_segmentation/common/src/adaboost_classifier.cpp
+++ b/ipa_room_segmentation/common/src/adaboost_classifier.cpp
@@ -233,9 +233,9 @@ void AdaboostClassifier::segmentMap(const cv::Mat& map_to_be_labeled, cv::Mat& s
 		if (boost::filesystem::exists(boost::filesystem::path(filename_room)) == false)
 			boost::filesystem::copy_file(filename_room_default, filename_room);
 #if CV_MAJOR_VERSION == 2
-		room_boost_.load(filename_room.c_str());
+    room_boost_.load<cv::ml::Boost>(filename_room.c_str());
 #else
-		room_boost_->load(filename_room.c_str());
+    room_boost_->load<cv::ml::Boost>(filename_room.c_str());
 #endif
 
 		std::string filename_hallway = classifier_storage_path + "semantic_hallway_boost.xml";
@@ -243,9 +243,9 @@ void AdaboostClassifier::segmentMap(const cv::Mat& map_to_be_labeled, cv::Mat& s
 		if (boost::filesystem::exists(boost::filesystem::path(filename_hallway)) == false)
 			boost::filesystem::copy_file(filename_hallway_default, filename_hallway);
 #if CV_MAJOR_VERSION == 2
-		hallway_boost_.load(filename_hallway.c_str());
+    hallway_boost_.load<cv::ml::Boost>(filename_hallway.c_str());
 #else
-		hallway_boost_->load(filename_hallway.c_str());
+    hallway_boost_->load<cv::ml::Boost>(filename_hallway.c_str());
 #endif
 
 		trained_ = true;

--- a/ipa_room_segmentation/common/src/cv_boost_loader.cpp
+++ b/ipa_room_segmentation/common/src/cv_boost_loader.cpp
@@ -3,15 +3,15 @@
 #if CV_MAJOR_VERSION == 2
 void loadBoost(CvBoost& boost, std::string const& filename)
 {
-  boost.load(filename.c_str());
+	boost.load(filename.c_str());
 }
 #else
 void loadBoost(cv::Ptr<cv::ml::Boost> boost, std::string const& filename)
 {
 #if CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION<=2
-  boost->load<cv::ml::Boost>(filename.c_str());
+	boost->load<cv::ml::Boost>(filename.c_str());
 #else
-  boost->load(filename.c_str());
+	boost->load(filename.c_str());
 #endif
 }
 #endif

--- a/ipa_room_segmentation/common/src/cv_boost_loader.cpp
+++ b/ipa_room_segmentation/common/src/cv_boost_loader.cpp
@@ -1,0 +1,17 @@
+#include <ipa_room_segmentation/cv_boost_loader.h>
+
+#if CV_MAJOR_VERSION == 2
+void loadBoost(CvBoost& boost, std::string const& filename)
+{
+  boost.load(filename.c_str());
+}
+#else
+void loadBoost(cv::Ptr<cv::ml::Boost> boost, std::string const& filename)
+{
+#if CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION<=2
+  boost->load<cv::ml::Boost>(filename.c_str());
+#else
+  boost->load(filename.c_str());
+#endif
+}
+#endif

--- a/ipa_room_segmentation/common/src/voronoi_random_field_segmentation.cpp
+++ b/ipa_room_segmentation/common/src/voronoi_random_field_segmentation.cpp
@@ -1228,10 +1228,10 @@ void VoronoiRandomFieldSegmentation::segmentMap(const cv::Mat& original_map, cv:
 		if (boost::filesystem::exists(boost::filesystem::path(filename_room)) == false)
 			boost::filesystem::copy_file(filename_room_default, filename_room);
 #if CV_MAJOR_VERSION == 2
-		room_boost_.load(filename_room.c_str());
+    room_boost_.load<cv::ml::Boost>(filename_room.c_str());
 #else
 		//room_boost_->load<cv::ml::Boost>(filename_room.c_str());
-		room_boost_->load(filename_room.c_str());
+    room_boost_->load<cv::ml::Boost>(filename_room.c_str());
 #endif
 
 		std::string filename_hallway = classifier_storage_path + "vrf_hallway_boost.xml";
@@ -1239,10 +1239,10 @@ void VoronoiRandomFieldSegmentation::segmentMap(const cv::Mat& original_map, cv:
 		if (boost::filesystem::exists(boost::filesystem::path(filename_hallway)) == false)
 			boost::filesystem::copy_file(filename_hallway_default, filename_hallway);
 #if CV_MAJOR_VERSION == 2
-		hallway_boost_.load(filename_hallway.c_str());
+    hallway_boost_.load<cv::ml::Boost>(filename_hallway.c_str());
 #else
 		//hallway_boost_->load<cv::ml::Boost>(filename_hallway.c_str());
-		hallway_boost_->load(filename_hallway.c_str());
+    hallway_boost_->load<cv::ml::Boost>(filename_hallway.c_str());
 #endif
 
 		std::string filename_doorway = classifier_storage_path + "vrf_doorway_boost.xml";
@@ -1250,10 +1250,10 @@ void VoronoiRandomFieldSegmentation::segmentMap(const cv::Mat& original_map, cv:
 		if (boost::filesystem::exists(boost::filesystem::path(filename_doorway)) == false)
 			boost::filesystem::copy_file(filename_doorway_default, filename_doorway);
 #if CV_MAJOR_VERSION == 2
-		doorway_boost_.load(filename_doorway.c_str());
+    doorway_boost_.load<cv::ml::Boost>(filename_doorway.c_str());
 #else
 		//doorway_boost_->load<cv::ml::Boost>(filename_doorway.c_str());
-		doorway_boost_->load(filename_doorway.c_str());
+    doorway_boost_->load<cv::ml::Boost>(filename_doorway.c_str());
 #endif
 
 		// set the trained-Boolean true to only load parameters once

--- a/ipa_room_segmentation/common/src/voronoi_random_field_segmentation.cpp
+++ b/ipa_room_segmentation/common/src/voronoi_random_field_segmentation.cpp
@@ -62,6 +62,7 @@
 #include <boost/filesystem.hpp>
 
 #include <ipa_room_segmentation/timer.h>
+#include <ipa_room_segmentation/cv_boost_loader.h>
 
 // This function is the optimization function L(w) = -1 * sum(i)(log(p(y_i|MB(y_i, w), x)) + ((w - w_r)^T (w - w_r)) / 2 * sigma^2)
 // to find the optimal weights for the given prelabeled map. to find these the function has to be minimized.
@@ -1227,34 +1228,19 @@ void VoronoiRandomFieldSegmentation::segmentMap(const cv::Mat& original_map, cv:
 		std::string filename_room_default = classifier_default_path + "vrf_room_boost.xml";
 		if (boost::filesystem::exists(boost::filesystem::path(filename_room)) == false)
 			boost::filesystem::copy_file(filename_room_default, filename_room);
-#if CV_MAJOR_VERSION == 2
-    room_boost_.load(filename_room.c_str());
-#else
-		//room_boost_->load<cv::ml::Boost>(filename_room.c_str());
-    room_boost_->load<cv::ml::Boost>(filename_room.c_str());
-#endif
+		loadBoost(room_boost_,filename_room);
 
 		std::string filename_hallway = classifier_storage_path + "vrf_hallway_boost.xml";
 		std::string filename_hallway_default = classifier_default_path + "vrf_hallway_boost.xml";
 		if (boost::filesystem::exists(boost::filesystem::path(filename_hallway)) == false)
 			boost::filesystem::copy_file(filename_hallway_default, filename_hallway);
-#if CV_MAJOR_VERSION == 2
-    hallway_boost_.load(filename_hallway.c_str());
-#else
-		//hallway_boost_->load<cv::ml::Boost>(filename_hallway.c_str());
-    hallway_boost_->load<cv::ml::Boost>(filename_hallway.c_str());
-#endif
+		loadBoost(hallway_boost_,filename_hallway);
 
 		std::string filename_doorway = classifier_storage_path + "vrf_doorway_boost.xml";
 		std::string filename_doorway_default = classifier_default_path + "vrf_doorway_boost.xml";
 		if (boost::filesystem::exists(boost::filesystem::path(filename_doorway)) == false)
 			boost::filesystem::copy_file(filename_doorway_default, filename_doorway);
-#if CV_MAJOR_VERSION == 2
-    doorway_boost_.load(filename_doorway.c_str());
-#else
-		//doorway_boost_->load<cv::ml::Boost>(filename_doorway.c_str());
-    doorway_boost_->load<cv::ml::Boost>(filename_doorway.c_str());
-#endif
+		loadBoost(doorway_boost_,filename_doorway);
 
 		// set the trained-Boolean true to only load parameters once
 		trained_boost_ = true;

--- a/ipa_room_segmentation/common/src/voronoi_random_field_segmentation.cpp
+++ b/ipa_room_segmentation/common/src/voronoi_random_field_segmentation.cpp
@@ -1228,7 +1228,7 @@ void VoronoiRandomFieldSegmentation::segmentMap(const cv::Mat& original_map, cv:
 		if (boost::filesystem::exists(boost::filesystem::path(filename_room)) == false)
 			boost::filesystem::copy_file(filename_room_default, filename_room);
 #if CV_MAJOR_VERSION == 2
-    room_boost_.load<cv::ml::Boost>(filename_room.c_str());
+    room_boost_.load(filename_room.c_str());
 #else
 		//room_boost_->load<cv::ml::Boost>(filename_room.c_str());
     room_boost_->load<cv::ml::Boost>(filename_room.c_str());
@@ -1239,7 +1239,7 @@ void VoronoiRandomFieldSegmentation::segmentMap(const cv::Mat& original_map, cv:
 		if (boost::filesystem::exists(boost::filesystem::path(filename_hallway)) == false)
 			boost::filesystem::copy_file(filename_hallway_default, filename_hallway);
 #if CV_MAJOR_VERSION == 2
-    hallway_boost_.load<cv::ml::Boost>(filename_hallway.c_str());
+    hallway_boost_.load(filename_hallway.c_str());
 #else
 		//hallway_boost_->load<cv::ml::Boost>(filename_hallway.c_str());
     hallway_boost_->load<cv::ml::Boost>(filename_hallway.c_str());
@@ -1250,7 +1250,7 @@ void VoronoiRandomFieldSegmentation::segmentMap(const cv::Mat& original_map, cv:
 		if (boost::filesystem::exists(boost::filesystem::path(filename_doorway)) == false)
 			boost::filesystem::copy_file(filename_doorway_default, filename_doorway);
 #if CV_MAJOR_VERSION == 2
-    doorway_boost_.load<cv::ml::Boost>(filename_doorway.c_str());
+    doorway_boost_.load(filename_doorway.c_str());
 #else
 		//doorway_boost_->load<cv::ml::Boost>(filename_doorway.c_str());
     doorway_boost_->load<cv::ml::Boost>(filename_doorway.c_str());


### PR DESCRIPTION
I get
``
/usr/include/opencv2/core.hpp:3074:44: note:   template argument deduction/substitution failed:
[..]/ipa_room_segmentation/common/src/voronoi_random_field_segmentation.cpp:1234:42: note:   couldn't deduce template parameter ‘_Tp’
   room_boost_->load(filename_room.c_str());
                                          ^
[..]/ipa_room_segmentation/common/src/voronoi_random_field_segmentation.cpp:1245:48: error: no matching function for call to ‘cv::ml::Boost::load(const char*)’
   hallway_boost_->load(filename_hallway.c_str());
``
when building this on melodic.
By explicitly stating the template arguments, this can be fixed