### PR TITLE
fix: include contains.h only once

### DIFF
--- a/ipa_room_segmentation/common/include/ipa_room_segmentation/contains.h
+++ b/ipa_room_segmentation/common/include/ipa_room_segmentation/contains.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "ros/ros.h"
 #include <opencv2/opencv.hpp>
 #include <opencv2/highgui/highgui.hpp>


### PR DESCRIPTION
After pulling the most recent state of the noetic_dev branch and building my project, I got a function redefinition error, presumably because the header file is included multiple times and there is no guard around that.

I added a guard and now I can build it without errors.

If you are interested in seeing my error messages, I'll send those upon request :)